### PR TITLE
feat(cnab240): ajustes layouts e namespaces

### DIFF
--- a/src/resources/B104/remessa/cnab240_sigcb/Registro0.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro0.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use \CnabPHP\resources\generico\remessa\cnab240\Generico0;
 use Exception;
 
@@ -75,12 +75,12 @@ class Registro0 extends Generico0
 			'default'=>'',
 			'tipo'=>'int','required'=>true),
 		'codigo_beneficiario'=>array(
-			'tamanho'=>6,
+			'tamanho'=>7,
 			'default'=>'',
 			'tipo'=>'int',
 			'required'=>true),
 		'uso_caixa2'=>array(
-			'tamanho'=>8,
+			'tamanho'=>7,
 			'default'=>'0',
 			'tipo'=>'int',
 			'required'=>true),
@@ -121,7 +121,7 @@ class Registro0 extends Generico0
 			'required'=>true),
 		'versao_layout'=>array(
 			'tamanho'=>3,
-			'default'=>'050',
+			'default'=>'101',
 			'tipo'=>'int',
 			'required'=>true),
 		'densidade_gravacao'=>array(

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro1.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro1.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico1;
 use Exception;
 
@@ -62,7 +62,7 @@ class Registro1 extends Generico1
 			'required'=>true),
 		'versa_layout'=>array(
 			'tamanho'=>3,
-			'default'=>'030',
+			'default'=>'067',
 			'tipo'=>'int',
 			'required'=>true),
 		'filler2'=>array(
@@ -81,12 +81,12 @@ class Registro1 extends Generico1
 			'tipo'=>'int',
 			'required'=>true),
 		'codigo_beneficiario'=>array(
-			'tamanho'=>6,
+			'tamanho'=>7,
 			'default'=>'',
 			'tipo'=>'int',
 			'required'=>true),
 		'uso_caixa1'=>array(
-			'tamanho'=>14,
+			'tamanho'=>13,
 			'default'=>'0',
 			'tipo'=>'int',
 			'required'=>true),

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro3P.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro3P.php
@@ -25,7 +25,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 
 use CnabPHP\resources\generico\remessa\cnab240\Generico3;
 use CnabPHP\RegistroRemAbstract;
@@ -82,12 +82,12 @@ class Registro3P extends Generico3 {
             'tipo' => 'alfa',
             'required' => true),
         'codigo_convenio' => array(//10.3P
-            'tamanho' => 6,
+            'tamanho' => 7,
             'default' => '0',
             'tipo' => 'int',
             'required' => true),
         'filler2' => array(// 11.3P
-            'tamanho' => 8,
+            'tamanho' => 7,
             'default' => '0',
             'tipo' => 'int',
             'required' => true),

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro3Q.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro3Q.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico3;
 use Exception;
 

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro3R.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro3R.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico3;
 use Exception;
 

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro3S1e2.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro3S1e2.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico3;
 use Exception;
 

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro3S3.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro3S3.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico3;
 use Exception;
 

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro5.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro5.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico5;
 use Exception;
 

--- a/src/resources/B104/remessa/cnab240_sigcb/Registro9.php
+++ b/src/resources/B104/remessa/cnab240_sigcb/Registro9.php
@@ -23,7 +23,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace CnabPHP\resources\B104\remessa\cnab240_SIGCB;
+namespace CnabPHP\resources\B104\remessa\cnab240_sigcb;
 use CnabPHP\resources\generico\remessa\cnab240\Generico9;
 use Exception;
 


### PR DESCRIPTION
Descrição:

Alterações realizadas:
### Ajustes CNAB Caixa – atualização de campos e namespaces

## Alterações realizadas

### Registro 0 – Header do Arquivo
- **Campo 10.0 (Código do Beneficiário):** expandido para 7 posições (posições 53 a 59).  
- **Campo 19.0 (Versão do Leiaute):** atualizado para valor `101` (posições 164 a 166).  

### Registro 1 – Header do Lote
- **Campo 09.1 (Versão do Leiaute do Lote):** atualizado para `067` (posições 14 a 16).  
- **Campo 12.1 (Código do Beneficiário):** expandido para 7 posições (posições 54 a 60).  

### Registro 3P – Segmento P
- **Campo 10.3P (Código do Convênio/Beneficiário):** expandido para 7 posições (posições 45 a 51).  

### Namespaces
- Todos os namespaces foram ajustados  (ex.: `cnab240_SIGCB` → `cnab240_sigcb`).  

## Testes realizados
- Geração de remessa via front-end no ambiente local do Proesc


<img width="1905" height="737" alt="Screenshot from 2026-02-06 11-14-27" src="https://github.com/user-attachments/assets/3c86a08e-bac1-4159-94c7-af1ac105182f" />
